### PR TITLE
[DONE] client.serve resilience and RPCTimeoutError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,10 @@
 0.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Client now raises RPCTimeoutError if the result of a RPC call took to long to
+  be received.
+
+- Client.serve() method respawns internal tasks on errors.
 
 
 0.1.3 (2019-08-21)


### PR DESCRIPTION
Fixes:
- client.serve() internal task crashes due to (unforeseen) errors.
- Custom RPCTimeoutError so you know the timeouterror is raised in the rpcclient.