### PR TITLE
[DONE] Numpy generic serialization

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,10 @@
 0.1.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Dropped Numpy save/load file serialize/deserialization for
+  a more generic approach that uses dictionaries instead. This
+  makes it easier to deserialize the Numpy array's in other
+  programming languages.
 
 
 0.1.7 (2020-01-10)


### PR DESCRIPTION
Swith from Numpy save/load functions to using dictonairies, this makes it
a lot easier to deserialize Numpy array's in other programming languages.