### PR TITLE
set redis from url parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,7 @@
 0.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set Redis socket keepalive and retry on timeout for RPCRedisCommLayer.
 
 
 0.3.1 (2025-04-14)

--- a/asyncio_rpc/commlayers/redis.py
+++ b/asyncio_rpc/commlayers/redis.py
@@ -36,7 +36,12 @@ class RPCRedisCommLayer(AbstractRPCCommLayer):
         self.serialization = serialization
 
         # Redis for publishing
-        self.redis = async_redis.from_url(f"redis://{host}")
+        self.redis = async_redis.from_url(
+            f"redis://{host}",
+            socket_keepalive=True,
+            retry_on_timeout=True,
+            health_check_interval=None,  # no health checks for Redis pub/sub
+        )
 
         # By default register all RPC models
         for model in SERIALIZABLE_MODELS:


### PR DESCRIPTION
for pub sub health check are not available. Set socket keepalive to persist Redis. 